### PR TITLE
Add modal demo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,10 @@ group :development do
   gem "standard"
 end
 
+group :test do
+  gem "mocha"
+end
+
 group :production do
   gem "pg"
   gem "honeybadger"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,6 +248,7 @@ DEPENDENCIES
   devise
   honeybadger
   listen (~> 3.2)
+  mocha
   motion
   pg
   pry-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,10 +87,10 @@ GEM
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     honeybadger (4.8.0)
-    i18n (1.8.9)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     i18n_data (0.11.0)
-    listen (3.5.0)
+    listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     loofah (2.9.0)
@@ -99,19 +99,18 @@ GEM
     lz4-ruby (0.3.3)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    marcel (1.0.0)
+    marcel (1.0.1)
     method_source (1.0.0)
     mini_mime (1.0.3)
-    mini_portile2 (2.5.0)
     minitest (5.14.4)
+    mocha (1.12.0)
     motion (0.5.0)
       lz4-ruby (>= 0.3.3)
       nokogiri
       rails (>= 5.1)
     msgpack (1.4.2)
     nio4r (2.5.7)
-    nokogiri (1.11.2)
-      mini_portile2 (~> 2.5.0)
+    nokogiri (1.11.2-x86_64-darwin)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.20.1)
@@ -239,7 +238,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-20
 
 DEPENDENCIES
   bootsnap (>= 1.4.2)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,6 +4,7 @@
 @import "window";
 @import "clicker_game";
 @import "go";
+@import "modal";
 
 .calc-grid {
   display: grid;

--- a/app/assets/stylesheets/modal.scss
+++ b/app/assets/stylesheets/modal.scss
@@ -1,0 +1,7 @@
+@import "_variables";
+
+button {
+  &.active {
+    border: 0.25em solid $primary;
+  }
+}

--- a/app/assets/stylesheets/modal.scss
+++ b/app/assets/stylesheets/modal.scss
@@ -2,6 +2,6 @@
 
 button {
   &.active {
-    border: 0.25em solid $primary;
+    border: 0.25em solid $primary-color;
   }
 }

--- a/app/components/modals/bootstrap_modal.html.erb
+++ b/app/components/modals/bootstrap_modal.html.erb
@@ -1,0 +1,34 @@
+<div>
+  <% if show_button? %>
+    <!-- Button to trigger modal -->
+    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#exampleModal">
+      Launch modal
+    </button>
+  <% end %>
+
+  <!-- Bootstrap Modal markup with mapped_motion :dismiss to capture when it is dismissed by clicking -->
+  <!-- Clicking the modal (ie - outside modal dialog) should dismiss and is dismissable -->
+  <div class="modal fade" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true" data-motion="dismiss" data-value="dismissable">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="exampleModalLabel">Modal title</h5>
+          <!-- Modal close button should also dismiss, so it also has data-motion -->
+          <!-- Note that you also need to add dismissable to span :( -->
+          <button type="button" class="close" data-value="dismissable" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true" data-value="dismissable">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <p><%= content %></p>
+          <p>You picked: <%= selected %></p>
+        </div>
+        <div class="modal-footer">
+          <!-- Modal save/close button should also dismiss, so it also has data-motion -->
+          <button type="button" class="btn btn-secondary" data-value="dismissable" data-dismiss="modal">Close</button>
+          <button type="button" class="btn btn-primary" data-value="dismissable" data-dismiss="modal">Save changes</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/components/modals/bootstrap_modal.rb
+++ b/app/components/modals/bootstrap_modal.rb
@@ -1,0 +1,42 @@
+module Modals
+  class BootstrapModal < ViewComponent::Base
+    include Motion::Component
+
+    attr_reader :selected, :content
+    map_motion :dismiss
+
+    def initialize(selected:, show_trigger:, modal_channel:, content:)
+      @selected = selected
+      @show_trigger = show_trigger
+      @modal_channel = modal_channel
+      @content = content
+    end
+
+    def show_button?
+      selected && @show_trigger
+    end
+
+    def dismiss(event)
+      # Unless you check that the thing they clicked to dismiss
+      # was also something that bootstrap uses to dismiss,
+      # you can trigger inconsistent state:
+      # 1. Broadcast below sent
+      # 2. Parent component responds to the broadcast by changing its state
+      # 3. Parent component will re-render
+      # 4. The modal will be 'open' without appearing open
+      #
+      # So make sure you either:
+      # a. do not change parent state from a child while modal is open
+      # b. only change parent state when modal is going to close
+      return unless event.target.data["value"] == "dismissable"
+
+      broadcast_user_dismissed_modal
+    end
+
+    private
+
+    def broadcast_user_dismissed_modal
+      ActionCable.server.broadcast(@modal_channel, {event: "dismiss-modal"})
+    end
+  end
+end

--- a/app/components/modals/bootstrap_modal.rb
+++ b/app/components/modals/bootstrap_modal.rb
@@ -1,14 +1,17 @@
+# frozen_string_literal: true
+
 module Modals
+  # Bootstrap Modal with Motion
   class BootstrapModal < ViewComponent::Base
     include Motion::Component
 
     attr_reader :selected, :content
     map_motion :dismiss
 
-    def initialize(selected:, show_trigger:, modal_channel:, content:)
+    def initialize(selected:, show_trigger:, on_dismiss:, content:)
       @selected = selected
       @show_trigger = show_trigger
-      @modal_channel = modal_channel
+      @on_dismiss = on_dismiss
       @content = content
     end
 
@@ -28,15 +31,9 @@ module Modals
       # So make sure you either:
       # a. do not change parent state from a child while modal is open
       # b. only change parent state when modal is going to close
-      return unless event.target.data["value"] == "dismissable"
+      return unless event.target.data['value'] == 'dismissable'
 
-      broadcast_user_dismissed_modal
-    end
-
-    private
-
-    def broadcast_user_dismissed_modal
-      ActionCable.server.broadcast(@modal_channel, {event: "dismiss-modal"})
+      @on_dismiss.call({ event: 'dismiss-modal' })
     end
   end
 end

--- a/app/components/modals/bootstrap_modal.rb
+++ b/app/components/modals/bootstrap_modal.rb
@@ -5,14 +5,14 @@ module Modals
   class BootstrapModal < ViewComponent::Base
     include Motion::Component
 
-    attr_reader :selected, :content
+    attr_reader :selected, :body
     map_motion :dismiss
 
-    def initialize(selected:, show_trigger:, on_dismiss:, content:)
+    def initialize(selected:, show_trigger:, on_dismiss:, body:)
       @selected = selected
       @show_trigger = show_trigger
       @on_dismiss = on_dismiss
-      @content = content
+      @body = body
     end
 
     def show_button?

--- a/app/components/modals/bootstrap_modal.rb
+++ b/app/components/modals/bootstrap_modal.rb
@@ -26,14 +26,14 @@ module Modals
       # 1. Broadcast below sent
       # 2. Parent component responds to the broadcast by changing its state
       # 3. Parent component will re-render
-      # 4. The modal will be 'open' without appearing open
+      # 4. The modal will be "open" without appearing open
       #
       # So make sure you either:
       # a. do not change parent state from a child while modal is open
       # b. only change parent state when modal is going to close
-      return unless event.target.data['value'] == 'dismissable'
+      return unless event.target.data["value"] == "dismissable"
 
-      @on_dismiss.call({ event: 'dismiss-modal' })
+      @on_dismiss.call({event: "dismiss-modal"})
     end
   end
 end

--- a/app/components/modals/modal_demo.html.erb
+++ b/app/components/modals/modal_demo.html.erb
@@ -1,0 +1,52 @@
+<div>
+  <section>
+    <h3>Select a number to display inside the modal.</h3>
+    <ul>
+      <% 5.times do |i| %>
+        <li>
+          <button
+            data-motion="selection"
+            data-value="<%= i + 1 %>"
+            class="<%= (selected == (i + 1).to_s ? 'active' : nil) %>"
+            <%= modal_mode == :modal ? 'data-toggle=modal data-target=#exampleModal' : nil %>
+          >
+            <%= numbers_to_words(i + 1) %>
+          </button>
+        </li>
+      <% end %>
+    </ul>
+  </section>
+
+  <section>
+    <h3>Select a mode of triggering the modal.</h3>
+    <ul>
+      <li>
+        <button data-motion="mode" data-value="motion" class="<%= modal_mode == :motion ? 'active' : nil %>">
+          Motion Modal - triggered by Motion upon selection
+        </button>
+      </li>
+      <li>
+        <button data-motion="mode" data-value="modal_with_trigger" class="<%= modal_mode == :modal_with_trigger ? 'active' : nil %>">
+          Bootstrap Modal - triggered by Bootstrap trigger button
+        </button>
+      </li>
+      <li>
+        <button data-motion="mode" data-value="modal" class="<%= modal_mode == :modal ? 'active' : nil %>">
+          Bootstrap Modal - triggered by Bootstrap upon selection
+        </button>
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h4>Current state </h4>
+    <p>Selected: <%= selected %></p>
+
+    <p>Mode: <%= modal_mode %></p>
+    <p><%= content %></p>
+  </section>
+  <%= render Modals::BootstrapModal.new(modal_channel: modal_channel, show_trigger: show_bootstrap_trigger?, selected: selected, content: content) %>
+  <% if open_motion_modal? %>
+    <%= render Modals::MotionModal.new(modal_channel: modal_channel, selected: selected, content: content) %>
+  <% end %>
+</div>

--- a/app/components/modals/modal_demo.html.erb
+++ b/app/components/modals/modal_demo.html.erb
@@ -45,8 +45,8 @@
     <p>Mode: <%= modal_mode %></p>
     <p><%= content %></p>
   </section>
-  <%= render Modals::BootstrapModal.new(modal_channel: modal_channel, show_trigger: show_bootstrap_trigger?, selected: selected, content: content) %>
+  <%= render Modals::BootstrapModal.new(on_dismiss: bind(:dismiss), show_trigger: show_bootstrap_trigger?, selected: selected, content: content) %>
   <% if open_motion_modal? %>
-    <%= render Modals::MotionModal.new(modal_channel: modal_channel, selected: selected, content: content) %>
+    <%= render Modals::MotionModal.new(on_dismiss: bind(:dismiss), selected: selected, content: content) %>
   <% end %>
 </div>

--- a/app/components/modals/modal_demo.html.erb
+++ b/app/components/modals/modal_demo.html.erb
@@ -1,24 +1,6 @@
 <div>
   <section>
-    <h3>Select a number to display inside the modal.</h3>
-    <ul>
-      <% 5.times do |i| %>
-        <li>
-          <button
-            data-motion="selection"
-            data-value="<%= i + 1 %>"
-            class="<%= (selected == (i + 1).to_s ? 'active' : nil) %>"
-            <%= modal_mode == :modal ? 'data-toggle=modal data-target=#exampleModal' : nil %>
-          >
-            <%= numbers_to_words(i + 1) %>
-          </button>
-        </li>
-      <% end %>
-    </ul>
-  </section>
-
-  <section>
-    <h3>Select a mode of triggering the modal.</h3>
+    <h3>Select a way to trigger the modal.</h3>
     <ul>
       <li>
         <button data-motion="mode" data-value="motion" class="<%= modal_mode == :motion ? 'active' : nil %>">
@@ -39,14 +21,33 @@
   </section>
 
   <section>
+    <h3>Select a number to display inside the modal.</h3>
+    <ul>
+      <% 5.times do |i| %>
+        <li>
+          <button
+            data-motion="selection"
+            data-value="<%= i + 1 %>"
+            class="<%= (selected == (i + 1).to_s ? 'active' : nil) %>"
+            <%= modal_mode == :modal ? 'data-toggle=modal data-target=#exampleModal' : nil %>
+          >
+            <%= numbers_to_words(i + 1) %>
+          </button>
+        </li>
+      <% end %>
+    </ul>
+  </section>
+
+  <section>
     <h4>Current state </h4>
     <p>Selected: <%= selected %></p>
 
     <p>Mode: <%= modal_mode %></p>
     <p><%= content %></p>
   </section>
+
   <%= render Modals::BootstrapModal.new(on_dismiss: bind(:dismiss), show_trigger: show_bootstrap_trigger?, selected: selected, content: content) %>
   <% if open_motion_modal? %>
-    <%= render Modals::MotionModal.new(on_dismiss: bind(:dismiss), selected: "1", content: "show_bootstrap_trigger") %>
+    <%= render Modals::MotionModal.new(on_dismiss: bind(:dismiss), selected: "1", content: "Show Bootstrap Trigger") %>
   <% end %>
 </div>

--- a/app/components/modals/modal_demo.html.erb
+++ b/app/components/modals/modal_demo.html.erb
@@ -47,6 +47,6 @@
   </section>
   <%= render Modals::BootstrapModal.new(on_dismiss: bind(:dismiss), show_trigger: show_bootstrap_trigger?, selected: selected, content: content) %>
   <% if open_motion_modal? %>
-    <%= render Modals::MotionModal.new(on_dismiss: bind(:dismiss), selected: selected, content: content) %>
+    <%= render Modals::MotionModal.new(on_dismiss: bind(:dismiss), selected: "1", content: "show_bootstrap_trigger") %>
   <% end %>
 </div>

--- a/app/components/modals/modal_demo.html.erb
+++ b/app/components/modals/modal_demo.html.erb
@@ -47,8 +47,8 @@
     </ul>
   </section>
 
-  <%= render Modals::BootstrapModal.new(on_dismiss: bind(:dismiss), show_trigger: show_bootstrap_trigger?, selected: selected, content: content) %>
+  <%= render Modals::BootstrapModal.new(on_dismiss: bind(:dismiss), show_trigger: show_bootstrap_trigger?, selected: selected, body: body) %>
   <% if open_motion_modal? %>
-    <%= render Modals::MotionModal.new(on_dismiss: bind(:dismiss), selected: "1", content: content) %>
+    <%= render Modals::MotionModal.new(on_dismiss: bind(:dismiss), selected: selected, body: body) %>
   <% end %>
 </div>

--- a/app/components/modals/modal_demo.html.erb
+++ b/app/components/modals/modal_demo.html.erb
@@ -21,7 +21,16 @@
   </section>
 
   <section>
+    <h4>Current state </h4>
+    <p>Selected: <%= selected %></p>
+
+    <p>Mode: <%= modal_mode %></p>
+    <p><%= content %></p>
+  </section>
+
+  <section>
     <h3>Select a number to display inside the modal.</h3>
+    <h6>Selecting the number will trigger the modal except for the Bootstrap trigger.</h6>
     <ul>
       <% 5.times do |i| %>
         <li>
@@ -38,16 +47,8 @@
     </ul>
   </section>
 
-  <section>
-    <h4>Current state </h4>
-    <p>Selected: <%= selected %></p>
-
-    <p>Mode: <%= modal_mode %></p>
-    <p><%= content %></p>
-  </section>
-
   <%= render Modals::BootstrapModal.new(on_dismiss: bind(:dismiss), show_trigger: show_bootstrap_trigger?, selected: selected, content: content) %>
   <% if open_motion_modal? %>
-    <%= render Modals::MotionModal.new(on_dismiss: bind(:dismiss), selected: "1", content: "Show Bootstrap Trigger") %>
+    <%= render Modals::MotionModal.new(on_dismiss: bind(:dismiss), selected: "1", content: content) %>
   <% end %>
 </div>

--- a/app/components/modals/modal_demo.rb
+++ b/app/components/modals/modal_demo.rb
@@ -1,0 +1,48 @@
+module Modals
+  class ModalDemo < ViewComponent::Base
+    include Motion::Component
+    delegate :numbers_to_words, to: :helpers
+    attr_reader :selected, :modal_mode
+
+    map_motion :selection
+    map_motion :mode
+
+    def initialize
+      @selected = nil
+      @modal_mode = :motion
+      stream_from modal_channel, :unselect
+    end
+
+    def content
+      {
+        modal: "Buttons will also reset selected state, but if user hits escape key, you cannot guarantee the state of selected goes back to nil.",
+        modal_with_trigger: "Buttons will also reset selected state, but if user hits escape key, you cannot guarantee the state of selected goes back to nil.  Use if buttons to select also reset parent state.",
+        motion: "Buttons should work to dismiss the modal, but the escape key will not, and focus is not captured.",
+      }[modal_mode]
+    end
+
+    def open_motion_modal?
+      modal_mode == :motion && selected.present?
+    end
+
+    def show_bootstrap_trigger?
+      modal_mode == :modal_with_trigger
+    end
+
+    def selection(event)
+      @selected = event.target.data["value"]
+    end
+
+    def mode(event)
+      @modal_mode = event.target.data["value"].to_sym
+    end
+
+    def unselect(_msg)
+      @selected = nil
+    end
+
+    def modal_channel
+      @modal_channel ||= SecureRandom.uuid
+    end
+  end
+end

--- a/app/components/modals/modal_demo.rb
+++ b/app/components/modals/modal_demo.rb
@@ -44,11 +44,11 @@ module Modals
     end
 
     def selection(event)
-      @selected = event.target.data['value']
+      @selected = event.target.data["value"]
     end
 
     def mode(event)
-      @modal_mode = event.target.data['value'].to_sym
+      @modal_mode = event.target.data["value"].to_sym
     end
 
     def dismiss(_msg)

--- a/app/components/modals/modal_demo.rb
+++ b/app/components/modals/modal_demo.rb
@@ -31,7 +31,7 @@ module Modals
       @modal_mode = :motion
     end
 
-    def content
+    def body
       CONTENT_DESCRIPTION[modal_mode]
     end
 

--- a/app/components/modals/modal_demo.rb
+++ b/app/components/modals/modal_demo.rb
@@ -1,8 +1,27 @@
+# frozen_string_literal: true
+
 module Modals
+  # Parent for modal demo
   class ModalDemo < ViewComponent::Base
     include Motion::Component
     delegate :numbers_to_words, to: :helpers
     attr_reader :selected, :modal_mode
+
+    description = <<~STR
+      Buttons will also reset selected state, but if user hits escape key, you cannot guarantee the state of selected goes back to nil.
+    STR
+    modal_trigger_description = <<~STR
+      Buttons will also reset selected state, but if user hits escape key, you cannot guarantee the state of selected goes back to nil.
+      Use if buttons to select also reset parent state.
+    STR
+    motion_description = <<~STR
+      Buttons should work to dismiss the modal, but the escape key will not, and focus is not captured.
+    STR
+    CONTENT_DESCRIPTION = {
+      modal: description,
+      modal_with_trigger: modal_trigger_description,
+      motion: motion_description
+    }.freeze
 
     map_motion :selection
     map_motion :mode
@@ -10,15 +29,10 @@ module Modals
     def initialize
       @selected = nil
       @modal_mode = :motion
-      stream_from modal_channel, :unselect
     end
 
     def content
-      {
-        modal: "Buttons will also reset selected state, but if user hits escape key, you cannot guarantee the state of selected goes back to nil.",
-        modal_with_trigger: "Buttons will also reset selected state, but if user hits escape key, you cannot guarantee the state of selected goes back to nil.  Use if buttons to select also reset parent state.",
-        motion: "Buttons should work to dismiss the modal, but the escape key will not, and focus is not captured.",
-      }[modal_mode]
+      CONTENT_DESCRIPTION[modal_mode]
     end
 
     def open_motion_modal?
@@ -30,14 +44,14 @@ module Modals
     end
 
     def selection(event)
-      @selected = event.target.data["value"]
+      @selected = event.target.data['value']
     end
 
     def mode(event)
-      @modal_mode = event.target.data["value"].to_sym
+      @modal_mode = event.target.data['value'].to_sym
     end
 
-    def unselect(_msg)
+    def dismiss(_msg)
       @selected = nil
     end
 

--- a/app/components/modals/motion_modal.html.erb
+++ b/app/components/modals/motion_modal.html.erb
@@ -1,0 +1,30 @@
+<div class="modal-open" data-motion="dismiss" data-value="dismissable">
+  <!-- This modal is styled with Bootstrap but triggered/displayed with motion -->
+  <!-- Bootstrap adds `.modal-open` to body, and instead we create a surrounding div with that class -->
+  <!-- Bootstrap uses css animations that are triggered when `.show` is added after the modal is in the DOM, so this component does that manually -->
+  <!-- Bootstrap sets the style to display: block; (normally display: none;) -->
+  <!-- Instead of using Bootstrap data-dismiss="modal" attributes, we use motion (data-motion="dismiss") to close the modal  -->
+  <div class="modal fade <%= modal_show_class %>" role="dialog" aria-labelledby="motionModalLabel" style="<%= modal_style %>" data-value="dismissable">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="motionModalLabel">Motion-Controlled Modal</h5>
+          <!-- Motion is used to dismiss, instead of Bootstrap -->
+          <button type="button" class="close" data-value="dismissable" aria-label="Close">
+            <span aria-hidden="true" data-value="dismissable">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <p><%= content %></p>
+          <p>You picked: <%= selected %></p>
+        </div>
+        <div class="modal-footer">
+          <!-- Motion is used to dismiss, instead of Bootstrap (data-motion instead of data-dismiss="modal") -->
+          <!-- Bootstrap data elements will not work because Bootstrap was not used to open the modal  -->
+          <button type="button" class="btn btn-secondary" data-value="dismissable">Close</button>
+          <button type="button" class="btn btn-primary" data-value="dismissable">Save changes</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/components/modals/motion_modal.html.erb
+++ b/app/components/modals/motion_modal.html.erb
@@ -15,7 +15,7 @@
           </button>
         </div>
         <div class="modal-body">
-          <p><%= content %></p>
+          <p><%= body %></p>
           <p>You picked: <%= selected %></p>
         </div>
         <div class="modal-footer">

--- a/app/components/modals/motion_modal.rb
+++ b/app/components/modals/motion_modal.rb
@@ -1,0 +1,66 @@
+module Modals
+  class MotionModal < ViewComponent::Base
+    include Motion::Component
+
+    attr_reader :modal_channel, :selected, :content, :show
+
+    map_motion :dismiss
+
+    def initialize(modal_channel:, selected:, content:)
+      @modal_channel = modal_channel
+      @selected = selected
+      @content = content
+      @show = false
+
+      every 0.1.second, :fade_in
+    end
+
+    ## Periodic timers
+    # The periodic timer allows the background to animate in and out
+    # If you didn't care about the css animation, you could remove them and
+    # broadcast in the `dismiss` method
+    def fade_in
+      @show = true
+
+      stop_periodic_timer :fade_in
+    end
+
+    def fade_out
+      # This actually closes the modal, 0.1s later
+      broadcast_user_dismissed_modal
+
+      stop_periodic_timer :fade_out
+    end
+    ## End Periodic timers
+
+    ## Map motion events
+    def dismiss(event)
+      # Did they click inside the modal, or click a button or outside modal to close
+      return unless event.target.data["value"] == "dismissable"
+
+      @show = false
+
+      every 0.1.second, :fade_out
+    end
+    ## End map motion events
+
+    # This adds a class that bootstrap adds with JS and causes a css animation
+    def modal_show_class
+      show ? "show" : nil
+    end
+
+    # This adds style that bootstrap adds with JS
+    def modal_style
+      <<-STYLE
+        display: block;
+        background-color: rgba(0, 0, 0, 0.6);
+      STYLE
+    end
+
+    private
+
+    def broadcast_user_dismissed_modal
+      ActionCable.server.broadcast(@modal_channel, {event: "dismiss-modal"})
+    end
+  end
+end

--- a/app/components/modals/motion_modal.rb
+++ b/app/components/modals/motion_modal.rb
@@ -5,14 +5,14 @@ module Modals
   class MotionModal < ViewComponent::Base
     include Motion::Component
 
-    attr_reader :selected, :content, :show
+    attr_reader :selected, :body, :show
 
     map_motion :dismiss
 
-    def initialize(on_dismiss:, selected:, content:)
+    def initialize(on_dismiss:, selected:, body:)
       @on_dismiss = on_dismiss
       @selected = selected
-      @content = content
+      @body = body
       @show = false
 
       every 0.1.second, :fade_in

--- a/app/components/modals/motion_modal.rb
+++ b/app/components/modals/motion_modal.rb
@@ -1,13 +1,16 @@
+# frozen_string_literal: true
+
 module Modals
+  # Modal controlled by motion
   class MotionModal < ViewComponent::Base
     include Motion::Component
 
-    attr_reader :modal_channel, :selected, :content, :show
+    attr_reader :selected, :content, :show
 
     map_motion :dismiss
 
-    def initialize(modal_channel:, selected:, content:)
-      @modal_channel = modal_channel
+    def initialize(on_dismiss:, selected:, content:)
+      @on_dismiss = on_dismiss
       @selected = selected
       @content = content
       @show = false
@@ -27,7 +30,7 @@ module Modals
 
     def fade_out
       # This actually closes the modal, 0.1s later
-      broadcast_user_dismissed_modal
+      @on_dismiss.call({ event: 'dismiss-modal' })
 
       stop_periodic_timer :fade_out
     end
@@ -36,7 +39,7 @@ module Modals
     ## Map motion events
     def dismiss(event)
       # Did they click inside the modal, or click a button or outside modal to close
-      return unless event.target.data["value"] == "dismissable"
+      return unless event.target.data['value'] == 'dismissable'
 
       @show = false
 
@@ -46,7 +49,7 @@ module Modals
 
     # This adds a class that bootstrap adds with JS and causes a css animation
     def modal_show_class
-      show ? "show" : nil
+      show ? 'show' : nil
     end
 
     # This adds style that bootstrap adds with JS
@@ -55,12 +58,6 @@ module Modals
         display: block;
         background-color: rgba(0, 0, 0, 0.6);
       STYLE
-    end
-
-    private
-
-    def broadcast_user_dismissed_modal
-      ActionCable.server.broadcast(@modal_channel, {event: "dismiss-modal"})
     end
   end
 end

--- a/app/components/modals/motion_modal.rb
+++ b/app/components/modals/motion_modal.rb
@@ -30,7 +30,7 @@ module Modals
 
     def fade_out
       # This actually closes the modal, 0.1s later
-      @on_dismiss.call({ event: 'dismiss-modal' })
+      @on_dismiss.call({event: "dismiss-modal"})
 
       stop_periodic_timer :fade_out
     end
@@ -39,7 +39,7 @@ module Modals
     ## Map motion events
     def dismiss(event)
       # Did they click inside the modal, or click a button or outside modal to close
-      return unless event.target.data['value'] == 'dismissable'
+      return unless event.target.data["value"] == "dismissable"
 
       @show = false
 
@@ -49,7 +49,7 @@ module Modals
 
     # This adds a class that bootstrap adds with JS and causes a css animation
     def modal_show_class
-      show ? 'show' : nil
+      show ? "show" : nil
     end
 
     # This adds style that bootstrap adds with JS

--- a/app/helpers/modal_helper.rb
+++ b/app/helpers/modal_helper.rb
@@ -1,0 +1,13 @@
+module ModalHelper
+  NUMBERS = {
+    1 => "one",
+    2 => "two",
+    3 => "three",
+    4 => "four",
+    5 => "five"
+  }
+
+  def numbers_to_words(number)
+    NUMBERS[number]
+  end
+end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -15,6 +15,8 @@ require("channels")
 //
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
-
+import "jquery"
+import "popper.js"
+import "bootstrap"
 import "controllers"
 import "motion"

--- a/app/views/demos/index.html.erb
+++ b/app/views/demos/index.html.erb
@@ -23,6 +23,10 @@
     <p>See time, in different time zones, with css animations (progress bar).</p>
   <% end %>
 
+  <%= link_to modal_demo_path, class: "list-group-item list-group-item-action pt-4" do %>
+    <h4>Modal Demo</h4>
+    <p>See how to work with modals with Bootstrap Modals.</p>
+  <% end %>
   <!-- <%= link_to go_index_path, class: "list-group-item list-group-item-action pt-4" do %> -->
   <!--   <h4>Go, The Surrounding Game</h4> -->
   <!--   <p>Play a 9x9 game of Go with a friend and share the game link with observers.</p> -->

--- a/app/views/demos/modal.html.erb
+++ b/app/views/demos/modal.html.erb
@@ -1,0 +1,15 @@
+<div class="row">
+  <div class="col-12">
+    <%= link_to "Back to All Demos", root_path %>
+    <h1>Motion Demos - Modals</h1>
+    <p>Motion and JS + Motion demos of modals</p>
+    <ul>
+      <li>Bootstrap is used to trigger modals. The rest is CSS and Ruby.</li>
+      <li>The page is never reloaded</li>
+    </ul>
+  </div>
+
+  <section class="my-4 col-md-8 col-sm-12">
+    <%= render Modals::ModalDemo.new %>
+  </section>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get "/clock", to: "demos#clock", as: :clock_demo
   get "/calculator", to: "demos#calculator", as: :calculator_demo
   get "/form", to: "demos#form", as: :form_demo
+  get "/modal", to: "demos#modal", as: :modal_demo
 
   resources :go, only: [:show, :create, :index] do
     post :join, on: :collection

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.2.2",
     "@unabridged/motion": "0.5.0",
+    "bootstrap": "^4.5.0",
+    "jquery": "^3.5.1",
+    "popper.js": "^1.16.1",
     "stimulus": "^1.1.1",
     "turbolinks": "^5.2.0"
   },

--- a/test/components/modals/bootstrap_modal_test.rb
+++ b/test/components/modals/bootstrap_modal_test.rb
@@ -9,9 +9,9 @@ module Modals
     let(:on_dismiss) { callback_stub }
     let(:selected) { 1 }
     let(:show) { true }
-    let(:content) { "Some content" }
+    let(:body) { "Some content" }
 
-    subject { klass.new(selected: selected, show_trigger: show, on_dismiss: on_dismiss, content: content) }
+    subject { klass.new(selected: selected, show_trigger: show, on_dismiss: on_dismiss, body: body) }
 
     describe "rendering" do
       it "renders as a motion component" do

--- a/test/components/modals/bootstrap_modal_test.rb
+++ b/test/components/modals/bootstrap_modal_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Modals
+  class BootstrapModalTest < ViewComponent::TestCase
+    include Motion::TestHelpers
+    let(:klass) { Modals::BootstrapModal }
+    let(:on_dismiss) { callback_stub }
+    let(:selected) { 1 }
+    let(:show) { true }
+    let(:content) { "Some content" }
+
+    subject { klass.new(selected: selected, show_trigger: show, on_dismiss: on_dismiss, content: content) }
+
+    describe "rendering" do
+      it "renders as a motion component" do
+        result = render_inline(subject).to_html
+        assert_match(/data-motion-key=/, result)
+      end
+
+      describe "when show is true" do
+        let(:show) { true }
+        it "renders modal plus trigger" do
+          result = render_inline(subject).to_html
+
+          assert_match(/class="modal fade"/, result)
+          assert_match(/id="exampleModalLabel"/, result)
+          assert_match(/data-target="#exampleModal"/, result)
+        end
+      end
+
+      describe "when show is false" do
+        let(:show) { false }
+        it "renders modal plus trigger" do
+          result = render_inline(subject).to_html
+
+          assert_match(/class="modal fade"/, result)
+          assert_match(/id="exampleModalLabel"/, result)
+          assert_no_match(/data-target="#exampleModal"/, result)
+        end
+      end
+    end
+
+    describe "motions" do
+      describe "#dismiss" do
+        let(:selected_value) { "dismissable" }
+        let(:params) { {target: {attributes: {"data-value" => selected_value}}} }
+        let(:event) { motion_event(params) }
+
+        describe "when dismissable event" do
+          let(:selected_value) { "dismissable" }
+
+          it "calls on_dismiss" do
+            on_dismiss.expects(:call)
+            run_motion(subject, :dismiss, event)
+          end
+        end
+
+        describe "when other event" do
+          let(:selected_value) { "other" }
+          it "does not call on_dismiss" do
+            on_dismiss.expects(:call).never
+            run_motion(subject, :dismiss, event)
+          end
+        end
+      end
+    end
+
+    describe "#show_button?" do
+      describe "when selected and show" do
+        let(:selected) { "1" }
+        let(:show) { true }
+        it { assert subject.show_button? }
+      end
+
+      describe "when selected and show" do
+        let(:selected) { [true, false].sample }
+        let(:show) { !selected }
+        it { refute subject.show_button? }
+      end
+    end
+  end
+end

--- a/test/components/modals/modal_demo_test.rb
+++ b/test/components/modals/modal_demo_test.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Modals
+  class ModalDemoTest < ViewComponent::TestCase
+    include Motion::TestHelpers
+    let(:klass) { Modals::ModalDemo }
+
+    subject { klass.new }
+
+    describe "rendering" do
+      it "shows 3 sections for mode, selection, and current state" do
+        result = render_inline(subject).to_html
+
+        assert_match("Select a mode of triggering the modal", result)
+        assert_match("Select a number to display inside the modal", result)
+        assert_match("Current state ", result)
+      end
+
+      it "renders as a motion component plus another motion component" do
+        result = render_inline(subject).to_html
+        assert_equal 3, result.split("data-motion-key=").length
+      end
+
+      describe "when open_motion_modal? is true" do
+        before { subject.instance_variable_set("@selected", "1") }
+        it "renders two other motion components" do
+          assert subject.open_motion_modal?
+          result = render_inline(subject).to_html
+          assert_equal 4, result.split("data-motion-key=").length
+        end
+      end
+    end
+
+    describe "motions" do
+      describe "#selection" do
+        let(:selected_value) { "new_value" }
+        let(:params) { {target: {attributes: {"data-value" => selected_value}}} }
+        let(:event) { motion_event(params) }
+
+        it "updates selected" do
+          assert_nil subject.selected
+
+          run_motion(subject, :selection, event)
+
+          assert_equal selected_value, subject.selected
+        end
+      end
+
+      describe "#mode" do
+        let(:mode) { "new_mode" }
+        let(:params) { {target: {attributes: {"data-value" => mode}}} }
+        let(:event) { motion_event(params) }
+
+        it "updates selected" do
+          assert_equal :motion, subject.modal_mode
+
+          run_motion(subject, :mode, event)
+
+          assert_equal mode.to_sym, subject.modal_mode
+        end
+      end
+    end
+
+    describe "stream_events" do
+      describe "#dismiss" do
+        let(:selected) { "selected" }
+        let(:params) { {target: {value: selected_value}} }
+        let(:event) { motion_event(params) }
+
+        it "resets selected" do
+          subject.instance_variable_set("@selected", selected)
+          assert_equal selected, subject.selected
+
+          process_broadcast(subject, :dismiss, {})
+
+          assert_nil subject.selected
+        end
+      end
+    end
+
+    describe "#show_bootstrap_trigger?" do
+      let(:modal_with_trigger_mode) { :modal_with_trigger }
+      let(:non_trigger_mode) { klass::CONTENT_DESCRIPTION.keys.reject { |cd| cd == modal_with_trigger_mode }.sample }
+
+      describe "when modal_mode is modal_with_trigger_mode" do
+        before { subject.instance_variable_set("@modal_mode", modal_with_trigger_mode) }
+        it { assert subject.show_bootstrap_trigger? }
+      end
+
+      describe "when modal_mode is not modal_with_trigger_mode" do
+        before { subject.instance_variable_set("@modal_mode", non_trigger_mode) }
+        it { refute subject.show_bootstrap_trigger? }
+      end
+    end
+
+    describe "#open_motion_modal?" do
+      let(:motion_mode) { :motion }
+      let(:non_motion_mode) { klass::CONTENT_DESCRIPTION.keys.reject { |cd| cd == motion_mode }.sample }
+
+      describe "when modal_mode is modal" do
+        before { subject.instance_variable_set("@modal_mode", motion_mode) }
+        describe "when selected is present" do
+          before { subject.instance_variable_set("@selected", true) }
+          it { assert subject.open_motion_modal? }
+        end
+
+        describe "when selected is not present" do
+          before { subject.instance_variable_set("@selected", false) }
+          it { refute subject.open_motion_modal? }
+        end
+      end
+
+      describe "when modal_mode is not modal" do
+        before do
+          subject.instance_variable_set("@selected", [true, false].sample)
+          subject.instance_variable_set("@modal_mode", non_motion_mode)
+        end
+        it { refute subject.open_motion_modal? }
+      end
+    end
+  end
+end

--- a/test/components/modals/modal_demo_test.rb
+++ b/test/components/modals/modal_demo_test.rb
@@ -13,7 +13,7 @@ module Modals
       it "shows 3 sections for mode, selection, and current state" do
         result = render_inline(subject).to_html
 
-        assert_match("Select a mode of triggering the modal", result)
+        assert_match("Select a way to trigger the modal", result)
         assert_match("Select a number to display inside the modal", result)
         assert_match("Current state ", result)
       end

--- a/test/components/modals/motion_modal_test.rb
+++ b/test/components/modals/motion_modal_test.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Modals
+  class MotionModalTest < ViewComponent::TestCase
+    include Motion::TestHelpers
+    let(:klass) { Modals::MotionModal }
+    let(:on_dismiss) { callback_stub }
+    let(:selected) { 1 }
+    let(:content) { "some content" }
+
+    subject { klass.new(selected: selected, on_dismiss: on_dismiss, content: content) }
+
+    describe "#initialize" do
+      it "sets show to false" do
+        refute subject.modal_show_class
+      end
+
+      it "creates periodic timer to call fade_out" do
+        handler = :fade_in
+        interval = 0.1.seconds
+        assert_equal interval, subject.periodic_timers[handler.to_s]
+      end
+    end
+
+    describe "rendering" do
+      it "renders as a motion component" do
+        result = render_inline(subject).to_html
+        assert_match(/data-motion-key=/, result)
+      end
+
+      it "renders modal" do
+        result = render_inline(subject).to_html
+
+        assert_match(/class="modal-open"/, result)
+        assert_match(/class="modal fade/, result)
+      end
+    end
+
+    describe "motions" do
+      describe "#dismiss" do
+        let(:selected_value) { "dismissable" }
+        let(:params) { {target: {attributes: {"data-value" => selected_value}}} }
+        let(:event) { motion_event(params) }
+
+        describe "when dismissable event" do
+          let(:selected_value) { "dismissable" }
+
+          it "sets show to false" do
+            subject.instance_variable_set("@show", true)
+            run_motion(subject, :dismiss, event)
+            refute subject.show
+          end
+
+          it "creates periodic timer to call fade_out" do
+            handler = :fade_out
+            interval = 0.1.seconds
+            run_motion(subject, :dismiss, event)
+            assert_equal interval, subject.periodic_timers[handler.to_s]
+          end
+        end
+
+        describe "when other event" do
+          let(:selected_value) { "other" }
+
+          it "does not call on_dismiss" do
+            on_dismiss.expects(:call).never
+            run_motion(subject, :dismiss, event)
+          end
+        end
+      end
+    end
+
+    describe "timers" do
+      describe "#fade_in" do
+        it "sets show to true" do
+          refute subject.show
+
+          subject.fade_in
+
+          assert subject.show
+        end
+
+        it "removes periodic timer for itself" do
+          assert subject.periodic_timers[:fade_in.to_s]
+          assert_changes -> { subject.periodic_timers[:fade_in.to_s] } do
+            subject.fade_in
+          end
+        end
+      end
+
+      describe "#fade_out" do
+        it "calls on_dismiss" do
+          on_dismiss.expects(:call)
+          subject.fade_out
+        end
+
+        it "removes periodic timer for itself" do
+          subject.every 1.second, :fade_out
+          assert_changes -> { subject.periodic_timers[:fade_out.to_s] } do
+            subject.fade_out
+          end
+        end
+      end
+    end
+
+    describe "#modal_show_class?" do
+      describe "when show" do
+        before { subject.instance_variable_set("@show", true) }
+        it { assert subject.modal_show_class }
+      end
+
+      describe "when not show" do
+        before { subject.instance_variable_set("@show", false) }
+        it { refute subject.modal_show_class }
+      end
+    end
+  end
+end

--- a/test/components/modals/motion_modal_test.rb
+++ b/test/components/modals/motion_modal_test.rb
@@ -8,9 +8,9 @@ module Modals
     let(:klass) { Modals::MotionModal }
     let(:on_dismiss) { callback_stub }
     let(:selected) { 1 }
-    let(:content) { "some content" }
+    let(:body) { "some content" }
 
-    subject { klass.new(selected: selected, on_dismiss: on_dismiss, content: content) }
+    subject { klass.new(selected: selected, on_dismiss: on_dismiss, body: body) }
 
     describe "#initialize" do
       it "sets show to false" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,10 +13,6 @@ def run_motion(component, motion_name, event = motion_event)
   component.process_motion(motion_name.to_s, event)
 end
 
-def motion_event(attrs = {})
-  Motion::Event.new(ActiveSupport::JSON.decode(attrs.to_json))
-end
-
 def callback_stub(method_name = :bound)
   Motion::Callback.new(BindMockComponent.new, method_name)
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,14 +1,43 @@
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
-require "minitest/autorun"
+
+require "minitest/spec"
+require "mocha/minitest"
+
+class BindMockComponent < ViewComponent::Base
+  include Motion::Component
+end
+
+def run_motion(component, motion_name, event = motion_event)
+  component.process_motion(motion_name.to_s, event)
+end
+
+def motion_event(attrs = {})
+  Motion::Event.new(ActiveSupport::JSON.decode(attrs.to_json))
+end
+
+def callback_stub(method_name = :bound)
+  Motion::Callback.new(BindMockComponent.new, method_name)
+end
+
+def process_broadcast(component, method_name, msg)
+  callback = component.bind(method_name)
+  component.process_broadcast(callback.broadcast, msg)
+end
 
 class ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
   # Run tests in parallel with specified workers
-  parallelize(workers: :number_of_processors)
+  # parallelize(workers: :number_of_processors)
 
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
+end
+
+class MiniTest::Spec
+  include ActiveSupport::Testing::TimeHelpers
+  include ActiveSupport::Testing::Assertions
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1489,6 +1489,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bootstrap@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.5.0.tgz#97d9dbcb5a8972f8722c9962483543b907d9b9ec"
+  integrity sha512-Z93QoXvodoVslA+PWNdk23Hze4RBYIkpb5h8I2HY2Tu2h7A0LpAgLcyrhrSUyo2/Oxm2l1fRZPs1e5hnxnliXA==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -3965,6 +3970,11 @@ jest-worker@^25.4.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jquery@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
+
 js-base64@^2.1.8:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.2.tgz#313b6274dda718f714d00b3330bbae6e38e90209"
@@ -5213,6 +5223,11 @@ pnp-webpack-plugin@^1.5.0:
   integrity sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==
   dependencies:
     ts-pnp "^1.1.6"
+
+popper.js@^1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
+  integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
 
 portfinder@^1.0.26:
   version "1.0.26"


### PR DESCRIPTION
# Description

Demonstrate how to use motion + modals (using Bootstrap).

1. Motion-only solution will not capture focus and will not allow user to use keyboard
1. Bootstrap can't be relied upon to change motion state if user uses keyboard (and can get into bad state if you are not careful)

# Note 
I don't know if we actually want to merge this, but as a demonstration of several ways to work with modals, I thought it was worth sharing with the team.