### PR TITLE
Add: motion v0.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     honeybadger (4.7.0)
-    i18n (1.8.3)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     i18n_data (0.10.0)
     listen (3.2.1)
@@ -105,7 +105,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
-    motion (0.2.2)
+    motion (0.4.0)
       nokogiri
       rails (>= 5.2)
     msgpack (1.3.3)
@@ -230,10 +230,10 @@ GEM
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
       railties (>= 4.2)
-    websocket-driver (0.7.2)
+    websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.3.1)
+    zeitwerk (2.4.0)
 
 PLATFORMS
   ruby

--- a/app/components/clicker_game_component.rb
+++ b/app/components/clicker_game_component.rb
@@ -7,6 +7,7 @@ class ClickerGameComponent < ViewComponent::Base
   delegate :channel, to: :game
   delegate :score, to: :player
 
+  after_disconnect :destroy_player
   map_motion :click
   map_motion :lucky_click
 
@@ -36,7 +37,7 @@ class ClickerGameComponent < ViewComponent::Base
     player.score_points(scored)
   end
 
-  def disconnected
+  def destroy_player
     player.destroy
     game.destroy if game.clicker_players.count == 0
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.2.2",
-    "@unabridged/motion": "^0.2.2",
+    "@unabridged/motion": "0.4.0",
     "stimulus": "^1.1.1",
     "turbolinks": "^5.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -922,10 +922,10 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
-"@unabridged/motion@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@unabridged/motion/-/motion-0.2.2.tgz#98921ed287c8cf9c53229f0d1bedf8cb236f9e02"
-  integrity sha512-bZ+mz3D66Eud9lS4sYLu9UwS9afT3icAVHuhrh+IkjhbftkkQ/6SClgz/5sx0+NtqCpGgSzsZl1ksUfPxv3Ybg==
+"@unabridged/motion@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@unabridged/motion/-/motion-0.4.0.tgz#ef06e94289bd1f760dda447748dd69dc6fde5bf9"
+  integrity sha512-SSqZuaM2RlzJekIqHnXBMACAr1qgCsbLonemCGM50z3e+IWucNFXdi+rMGdwUVRtEh6/XC0p2yi8pSYBJnOC9Q==
   dependencies:
     "@rails/actioncable" ">= 6.0"
     morphdom "^2.6.1"


### PR DESCRIPTION
I tested all of the working demos manually and did not notice anything broken.

I replaced the `disconnected` method in the clicker game with an `after_disconnect` callback.

I wanted to use the same callback for the Go demo, so I opened this PR and have rebased the Go PR off of this branch. I believe Go is ready to "go" now, certainly more that could be done, but it all works as far as I can tell, and now games will be deleted when the last person disconnects, like the clicker game.