### PR TITLE
Use local true instead of ajax posting for form

### DIFF
--- a/app/components/form_component.html.erb
+++ b/app/components/form_component.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @signup, url: "/form", data: { motion: 'change->validate submit->save' } do |f| %>
+<%= form_with model: @signup, url: "/form", local: true, data: { motion: 'change->validate submit->save' } do |f| %>
   <div class="form-group row">
     <%= f.label :name, class: "col-sm-2 col-form-label" %>
     <div class="col-sm-10">


### PR DESCRIPTION
# Description

When you submit the form with `form_with`, it uses AJAX to submit it by default.

This makes it use regular HTML to submit, and motion prevents the event default from happening, so no more console errors!

https://guides.rubyonrails.org/form_helpers.html#how-do-forms-with-patch-put-or-delete-methods-work-questionmark