### PR TITLE
Styling updates for accessibility & prettiness

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -1,4 +1,7 @@
+
+
 $primary-color: #0a406b; // dark blue
+
 $primary-color-dark: #24364d; // darker blue
 $primary-color-light: lighten($primary-color, 20%); // lighter blue
 $secondary-color: #5d9f3d; // green
@@ -9,3 +12,11 @@ $light-gray: #f8f9ff;
 $medium-light-gray: #e9ebf3;
 $medium-gray: #d4d7e4;
 $red: #FF4B3E;
+
+
+// bootstrap overrides
+$primary: $primary-color;
+$secondary: $secondary-color-dark;
+@import "bootstrap/scss/functions";
+@import "bootstrap/scss/variables";
+@import "bootstrap/scss/mixins";

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -1,7 +1,4 @@
-
-
 $primary-color: #0a406b; // dark blue
-
 $primary-color-dark: #24364d; // darker blue
 $primary-color-light: lighten($primary-color, 20%); // lighter blue
 $secondary-color: #5d9f3d; // green
@@ -17,6 +14,12 @@ $red: #FF4B3E;
 // bootstrap overrides
 $primary: $primary-color;
 $secondary: $secondary-color-dark;
+
+$navbar-light-color:                rgba(0,0,0, .7) !default;
+$navbar-light-hover-color:          rgba(0,0,0, .9) !default;
+$navbar-light-active-color:         rgba(0,0,0, .8) !default;
+$navbar-light-disabled-color:       rgba(0,0,0, .5) !default;
+
 @import "bootstrap/scss/functions";
 @import "bootstrap/scss/variables";
 @import "bootstrap/scss/mixins";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,5 @@
-@import "bootstrap";
 @import "_variables";
+@import "bootstrap";
 @import "clock";
 @import "window";
 @import "clicker_game";

--- a/app/assets/stylesheets/modal.scss
+++ b/app/assets/stylesheets/modal.scss
@@ -5,3 +5,19 @@ button {
     border: 0.25em solid $primary-color;
   }
 }
+
+#modal-demos {
+  .display-options {
+    display: flex;
+
+    button {
+      margin-right: 10px;
+    }
+  }
+  .triggers {
+    button {
+      margin-bottom: 10px;
+    }
+    
+  }
+}

--- a/app/assets/stylesheets/modal.scss
+++ b/app/assets/stylesheets/modal.scss
@@ -4,6 +4,9 @@ button {
   &.active {
     border: 0.25em solid $primary-color;
   }
+  &.active::before {
+    content: '✓';
+  }
 }
 
 #modal-demos {

--- a/app/components/calculator_component.html.erb
+++ b/app/components/calculator_component.html.erb
@@ -1,4 +1,4 @@
-<main class="calc-grid">
+<div class="calc-grid">
   <div class="buffer buffer-area"> <%= current_value %> </div>
 
   <%= button_tag "C", class: "number-btn", data: { motion: "clear" } %>
@@ -24,4 +24,4 @@
   <%= button_tag "0", class: "number-btn zero-button", data: { motion: "add_char", char: "0" } %>
   <%= button_tag ".", class: "number-btn", data: { motion: "add_char", char: "." } %>
   <%= button_tag "=", class: "op-btn", data: { motion: "equals" } %>
-</main>
+</div>

--- a/app/components/modals/bootstrap_modal.html.erb
+++ b/app/components/modals/bootstrap_modal.html.erb
@@ -12,7 +12,7 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title" id="exampleModalLabel">Modal title</h5>
+          <h3 class="modal-title" id="exampleModalLabel">Modal title</h3>
           <!-- Modal close button should also dismiss, so it also has data-motion -->
           <!-- Note that you also need to add dismissable to span :( -->
           <button type="button" class="close" data-value="dismissable" data-dismiss="modal" aria-label="Close">

--- a/app/components/modals/modal_demo.html.erb
+++ b/app/components/modals/modal_demo.html.erb
@@ -3,17 +3,17 @@
     <h2>Select a way to trigger the modal.</h2>
     <ul class="list-unstyled triggers">
       <li>
-        <button data-motion="mode" data-value="motion" class="btn btn-outline-primary <%= modal_mode == :motion ? 'active' : nil %>">
+        <button data-motion="mode" data-value="motion" class="btn btn-outline-primary <%= modal_mode == :motion ? 'active' : nil %>" aria-pressed="<%= modal_mode == :motion %>">
           Motion Modal - triggered by Motion upon selection
         </button>
       </li>
       <li>
-        <button data-motion="mode" data-value="modal_with_trigger" class="btn btn-outline-primary <%= modal_mode == :modal_with_trigger ? 'active' : nil %>">
+        <button data-motion="mode" data-value="modal_with_trigger" class="btn btn-outline-primary <%= modal_mode == :modal_with_trigger ? 'active' : nil %>" aria-pressed="<%= modal_mode == :motion %>">
           Bootstrap Modal - triggered by Bootstrap trigger button
         </button>
       </li>
       <li>
-        <button data-motion="mode" data-value="modal" class="btn btn-outline-primary <%= modal_mode == :modal ? 'active' : nil %>">
+        <button data-motion="mode" data-value="modal" class="btn btn-outline-primary <%= modal_mode == :modal ? 'active' : nil %>" aria-pressed="<%= modal_mode == :motion %>">
           Bootstrap Modal - triggered by Bootstrap upon selection
         </button>
       </li>

--- a/app/components/modals/modal_demo.html.erb
+++ b/app/components/modals/modal_demo.html.erb
@@ -1,6 +1,6 @@
 <div>
   <section>
-    <h3>Select a way to trigger the modal.</h3>
+    <h2>Select a way to trigger the modal.</h2>
     <ul>
       <li>
         <button data-motion="mode" data-value="motion" class="<%= modal_mode == :motion ? 'active' : nil %>">
@@ -21,7 +21,7 @@
   </section>
 
   <section>
-    <h4>Current state </h4>
+    <h2>Current state </h2>
     <p>Selected: <%= selected %></p>
 
     <p>Mode: <%= modal_mode %></p>
@@ -29,8 +29,8 @@
   </section>
 
   <section>
-    <h3>Select a number to display inside the modal.</h3>
-    <h6>Selecting the number will trigger the modal except for the Bootstrap trigger.</h6>
+    <h2>Select a number to display inside the modal.</h2>
+    <p>Selecting the number will trigger the modal except for the Bootstrap trigger.</p>
     <ul>
       <% 5.times do |i| %>
         <li>

--- a/app/components/modals/modal_demo.html.erb
+++ b/app/components/modals/modal_demo.html.erb
@@ -1,19 +1,19 @@
-<div>
+<div id="modal-demos">
   <section>
     <h2>Select a way to trigger the modal.</h2>
-    <ul>
+    <ul class="list-unstyled triggers">
       <li>
-        <button data-motion="mode" data-value="motion" class="<%= modal_mode == :motion ? 'active' : nil %>">
+        <button data-motion="mode" data-value="motion" class="btn btn-outline-primary <%= modal_mode == :motion ? 'active' : nil %>">
           Motion Modal - triggered by Motion upon selection
         </button>
       </li>
       <li>
-        <button data-motion="mode" data-value="modal_with_trigger" class="<%= modal_mode == :modal_with_trigger ? 'active' : nil %>">
+        <button data-motion="mode" data-value="modal_with_trigger" class="btn btn-outline-primary <%= modal_mode == :modal_with_trigger ? 'active' : nil %>">
           Bootstrap Modal - triggered by Bootstrap trigger button
         </button>
       </li>
       <li>
-        <button data-motion="mode" data-value="modal" class="<%= modal_mode == :modal ? 'active' : nil %>">
+        <button data-motion="mode" data-value="modal" class="btn btn-outline-primary <%= modal_mode == :modal ? 'active' : nil %>">
           Bootstrap Modal - triggered by Bootstrap upon selection
         </button>
       </li>
@@ -31,13 +31,13 @@
   <section>
     <h2>Select a number to display inside the modal.</h2>
     <p>Selecting the number will trigger the modal except for the Bootstrap trigger.</p>
-    <ul>
+    <ul class="list-unstyled display-options">
       <% 5.times do |i| %>
         <li>
           <button
             data-motion="selection"
             data-value="<%= i + 1 %>"
-            class="<%= (selected == (i + 1).to_s ? 'active' : nil) %>"
+            class="btn btn-outline-primary <%= (selected == (i + 1).to_s ? 'active' : nil) %>"
             <%= modal_mode == :modal ? 'data-toggle=modal data-target=#exampleModal' : nil %>
           >
             <%= numbers_to_words(i + 1) %>

--- a/app/components/modals/motion_modal.html.erb
+++ b/app/components/modals/motion_modal.html.erb
@@ -8,7 +8,7 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title" id="motionModalLabel">Motion-Controlled Modal</h5>
+          <h2 class="modal-title" id="motionModalLabel">Motion-Controlled Modal</h2>
           <!-- Motion is used to dismiss, instead of Bootstrap -->
           <button type="button" class="close" data-value="dismissable" aria-label="Close">
             <span aria-hidden="true" data-value="dismissable">&times;</span>

--- a/app/views/demos/index.html.erb
+++ b/app/views/demos/index.html.erb
@@ -2,39 +2,45 @@
 <p><%= link_to "Motion", "https://github.com/unabridged/motion" %> is a library that allows you to build reactive frontend UI components in your Rails application using pure Ruby. The full source for these demos can be found on <%= link_to "Github", "https://github.com/unabridged/motion-demos" %>.</p>
 
 <h2>All Demos</h2>
-<ul class="list-group col-xs-12 col-md-8">
-  <%= link_to calculator_demo_path, class: "list-group-item list-group-item-action pt-4" do %>
-    <h4>Calculator</h4>
-    <p>Allow complex frontend user interactions to generate results in real time with zero JS.</p>
-  <% end %>
-
-  <%= link_to form_demo_path, class: "list-group-item list-group-item-action pt-4" do %>
-    <h4>Form Validation</h4>
-    <p>Validate user input in real time with no JS and no repeated code from server to client.</p>
-  <% end %>
-
-  <%= link_to clicker_games_path, class: "list-group-item list-group-item-action pt-4" do %>
-    <h4>Clicker Game</h4>
+<ul class="list-group col-xs-12 col-md-8 list-unstyled">
+  <li>
+    <%= link_to calculator_demo_path, class: "list-group-item list-group-item-action pt-4" do %>
+      <h3>Calculator</h3>
+      <p>Allow complex frontend user interactions to generate results in real time with zero JS.</p>
+    <% end %>
+  </li>
+  <li>
+    <%= link_to form_demo_path, class: "list-group-item list-group-item-action pt-4" do %>
+      <h3>Form Validation</h3>
+      <p>Validate user input in real time with no JS and no repeated code from server to client.</p>
+    <% end %>
+  </li>
+  <li>
+    <%= link_to clicker_games_path, class: "list-group-item list-group-item-action pt-4" do %>
+    <h3>Clicker Game</h3>
     <p>Multi-user game streaming real-time events between all players and updating UI accordingly.</p>
   <% end %>
-
-  <%= link_to clock_demo_path, class: "list-group-item list-group-item-action pt-4" do %>
-    <h4>Clock Animation</h4>
+  </li>
+  <li>
+    <%= link_to clock_demo_path, class: "list-group-item list-group-item-action pt-4" do %>
+    <h3>Clock Animation</h3>
     <p>See time, in different time zones, with css animations (progress bar).</p>
   <% end %>
-
-  <%= link_to modal_demo_path, class: "list-group-item list-group-item-action pt-4" do %>
-    <h4>Modal Demo</h4>
+  </li>
+  <li>
+    <%= link_to modal_demo_path, class: "list-group-item list-group-item-action pt-4" do %>
+    <h3>Modal Demo</h3>
     <p>See how to work with modals with Bootstrap Modals.</p>
   <% end %>
-
-  <%= link_to live_preview_path, class: "list-group-item list-group-item-action pt-4" do %>
-    <h4>Live Preview</h4>
+  </li>
+  <li>
+    <%= link_to live_preview_path, class: "list-group-item list-group-item-action pt-4" do %>
+    <h3>Live Preview</h3>
     <p>Type in a form and see an immediate preview.</p>
   <% end %>
-
+  </li>
   <!-- <%= link_to go_index_path, class: "list-group-item list-group-item-action pt-4" do %> -->
-  <!--   <h4>Go, The Surrounding Game</h4> -->
+  <!--   <h3>Go, The Surrounding Game</h3> -->
   <!--   <p>Play a 9x9 game of Go with a friend and share the game link with observers.</p> -->
   <!-- <% end %> -->
 </ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>Motion Demos</title>
   <%= csrf_meta_tags %>
@@ -22,8 +22,8 @@
     </ul>
   </nav>
 
-  <div class="container mt-4">
+  <main class="container mt-4 mb-4">
     <%= yield %>
-  </div>
+  </main>
 </body>
 </html>

--- a/app/views/layouts/clicker.html.erb
+++ b/app/views/layouts/clicker.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>Motion Demos</title>
   <%= csrf_meta_tags %>
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-  <div class="container mt-4">
+  <main class="container mt-4 mb-4">
     <div class="row">
       <div class="col">
         <%= link_to "Back to All Demos", root_path %>
@@ -27,6 +27,6 @@
         <%= yield %>
       </div>
     </div>
-  </div>
+  </main>
 </body>
 </html>

--- a/app/views/layouts/go.html.erb
+++ b/app/views/layouts/go.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>Motion Demos</title>
   <%= csrf_meta_tags %>
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-  <div class="container mt-4">
+  <main class="container mt-4 mb-4">
     <div class="row">
       <div class="col">
         <%= link_to "Back to All Demos", root_path %>
@@ -28,6 +28,6 @@
         <%= yield %>
       </div>
     </div>
-  </div>
+  </main>
 </body>
 </html>


### PR DESCRIPTION
Correct accessibility issues flagged in Axe, including: 
 - making sure heading levels only increase by 1
 - making sure there's one & only one `main` element on each page 
 - adjusting colors for greater contrast
 - fixing HTML semantics issues like `ul` that contained elements other than `li`
 - adds `aria-pressed` to buttons that are being used as toggle buttons so screenreader users can know which one is selected

Other layout/stylistic fixes, like adding padding to the bottom of each page container with `mb-4`, padding between buttons etc. 
<img width="774" alt="screenshot of motion demos modals page" src="https://user-images.githubusercontent.com/4480480/115777164-9240f400-a37a-11eb-8e83-1236eeb081d5.png">
